### PR TITLE
MOD: content error

### DIFF
--- a/reader-web/src/main/webapp/src/locales/messages.zh.js
+++ b/reader-web/src/main/webapp/src/locales/messages.zh.js
@@ -143,7 +143,7 @@
     }
   },
   "article": {
-    "markasunread": "标记为已读"
+    "markasunread": "标记为未读"
   },
   "feed": {
     "nomorearticles": "没有更多条目",


### PR DESCRIPTION
I found a misspelling when using it:
“已读” means read
”未读“ means unread