### PR TITLE
Trailing spaces

### DIFF
--- a/reader-distribution-debian/src/main/package/etc/init.d/reader
+++ b/reader-distribution-debian/src/main/package/etc/init.d/reader
@@ -133,5 +133,3 @@ case "$1" in
 	exit 3
 	;;
 esac
-
-:


### PR DESCRIPTION
I couldn't start the service because of the trailing space in the init file and the ":" at the end.
The systemd error was : 
reader.service: Failed at step EXEC spawning /etc/init.d/reader: No such file or directory